### PR TITLE
Add /api/ prefix to item app urls

### DIFF
--- a/webapp/marketplace/urls.py
+++ b/webapp/marketplace/urls.py
@@ -19,56 +19,56 @@ urlpatterns = [
         kwargs={"permission_classes": [permissions.IsAdminUser]},
     ),
     path(
-        "categories/",
+        "api/categories/",
         CategoryViewSet.as_view({"get": "list", "post": "create"}),
         name="category-list",
     ),
     path(
-        "categories/<int:pk>/",
+        "api/categories/<int:pk>/",
         CategoryViewSet.as_view(
             {"get": "retrieve", "put": "update", "delete": "destroy"}
         ),
         name="category-detail",
     ),
     path(
-        "products/",
+        "api/products/",
         ProductViewSet.as_view({"get": "list", "post": "create"}),
         name="product-list",
     ),
     path(
-        "products/accepted",
+        "api/products/accepted",
         ProductViewSet.as_view({"get": "accepted"}),
         name="product-accepted",
     ),
     path(
-        "products/<int:pk>/",
+        "api/products/<int:pk>/",
         ProductViewSet.as_view(
             {"get": "retrieve", "put": "update", "delete": "destroy"}
         ),
         name="product-detail",
     ),
     path(
-        "products/<int:pk>/reject/",
+        "api/products/<int:pk>/reject/",
         ProductViewSet.as_view({"post": "reject"}),
         name="product-reject",
     ),
     path(
-        "products/<int:pk>/ban/",
+        "api/products/<int:pk>/ban/",
         ProductViewSet.as_view({"post": "ban"}),
         name="product-ban",
     ),
     path(
-        "products/<int:pk>/accept/",
+        "api/products/<int:pk>/accept/",
         ProductViewSet.as_view({"post": "accept"}),
         name="product-accept",
     ),
     path(
-        "products/<int:pk>/move-to-new/",
+        "api/products/<int:pk>/move-to-new/",
         ProductViewSet.as_view({"post": "move_to_new"}),
         name="product-move-to-new",
     ),
     path(
-        "products/<int:pk>/move-to-new-from-rejected/",
+        "api/products/<int:pk>/move-to-new-from-rejected/",
         ProductViewSet.as_view({"post": "move_to_new_from_rejected"}),
         name="product-move-to-new-from-rejected",
     ),


### PR DESCRIPTION
add `api` as prefix for Item app urls holding Product and Category logic